### PR TITLE
Fixed regex intented to replace CodeMirror files.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -57,7 +57,7 @@ module.exports = function(grunt) {
         options: {
           replacements: [
             {
-              pattern: /<!-- codemirror includes -->(.*?)<!-- codemirror includes end -->/ig,
+              pattern: /<!-- codemirror includes -->([\s\S]*?)<!-- codemirror includes end -->/g,
               replacement: '<link rel="stylesheet" href="cm/cm.min.css"><script src="cm/cm.min.js"></script>'
             },
             {


### PR DESCRIPTION
The CodeMirror files (*.css and *.js) are compressed into a single css
and js file. The regex which should do the release replacement was
invalid and did no longer match after js-beautifier cleaned the HTML.