### PR TITLE
Fix missing space between buttons.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -80,8 +80,9 @@ module.exports = function(grunt) {
     htmlmin: {
         dist: {
           options: {
-            removeComments     : true,
-            collapseWhitespace : true
+            removeComments       : true,
+            collapseWhitespace   : true,
+            conservativeCollapse : true
           },
           files: [
             {


### PR DESCRIPTION
Due to a misconfigured htmlminify a to HTML relevant space was removed.
Adjusted the configuration, such that these characters remain.